### PR TITLE
Bump rust version to 1.40

### DIFF
--- a/fortuneservice/Dockerfile
+++ b/fortuneservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.39.0-slim-buster as build
+FROM rust:1.40.0-slim-buster as build
 
 ENV RUST_LOG fortune=info
 ENV FORTUNE_PATH /usr/games/fortune

--- a/frontendservice/Dockerfile
+++ b/frontendservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.39.0-slim-buster as build
+FROM rust:1.40.0-slim-buster as build
 
 ENV RUST_LOG frontend=info
 ENV FORTUNE_SERVICE_HOSTNAME fortuneservice


### PR DESCRIPTION
Currently the build (using the rust available on the vm in github runner) using version 1.39 but the integration test would use 1.40 with this change.

Doesn't seem like it matters though...