### PR TITLE
Switch to actions-rs github action for rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Show rust version
-        working-directory: frontendservice
-        run: cargo version
+      - name: Update rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          profile: minimal
+          override: true
       - name: Build frontendservice
         working-directory: frontendservice
         run: cargo build
@@ -31,9 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Show rust version
-        working-directory: frontendservice
-        run: cargo version
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          profile: minimal
+          override: true
       - name: Build fortuneservice
         working-directory: fortuneservice
         run: cargo build


### PR DESCRIPTION
It is not clear how often the virtual environments are updated for github actions. actions-rs seems to be a more actively maintained github action for rust toolchain.

Signed-off-by: Pradip Caulagi <caulagi@gmail.com>