### PR TITLE
Reduce build time by starting integration test early

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         working-directory: frontendservice
         run: cargo build
         env:
-          GETENT_PATH: /usr/bin/getent
           RUST_LOG: frontend=info
       - name: Check format frontendservice
         working-directory: frontendservice
@@ -46,7 +45,6 @@ jobs:
         working-directory: fortuneservice
         run: cargo build
         env:
-          FORTUNE_PATH: /usr/bin/fortune
           RUST_LOG: fortune=info
       - name: Check format fortuneservice
         working-directory: fortuneservice
@@ -55,9 +53,6 @@ jobs:
   integration-test:
     name: Integration test
     if: "!contains(github.event.head_commit.message, 'e2e skip') && !contains(github.event.head_commit.message, 'skip e2e')"
-    needs:
-      - build-frontend
-      - build-fortune
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Don't wait for individual build to finish before starting integration test.